### PR TITLE
Fixed docs; remove_alt was mistakenly referenced instead of remove

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@
 //!
 //! The keys have two distinct types - `K1` and `K2` - which may be the same.
 //! Accessing on the primary `K1` key is via the usual `get`, `get_mut` and
-//! `remove_alt` methods, while accessing via the secondary `K2` key is via new
+//! `remove` methods, while accessing via the secondary `K2` key is via new
 //! `get_alt`, `get_mut_alt` and `remove_alt` methods. The value is of type `V`.
 //!
 //! Internally, two `HashMap`s are created - a main one on `<K1, (K2,


### PR DESCRIPTION
Hi, I believe the intent here was to reference `remove` and not `remove_alt`.  If not, please disregard!